### PR TITLE
Extract SelectionSet from Query

### DIFF
--- a/test/query-test.js
+++ b/test/query-test.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import Query from '../src/query';
+import {Query} from '../src/query';
 import typeBundle from '../fixtures/types'; // eslint-disable-line import/no-unresolved
 
 suite('Unit | Query', () => {
@@ -9,122 +9,16 @@ suite('Unit | Query', () => {
     return query.split(querySplitter);
   }
 
-  test('it builds queries off the root', () => {
-    const query = new Query(typeBundle);
-
-    assert.deepEqual(splitQuery(query.toString()), splitQuery('query { }'));
-  });
-
-  test('it builds queries off the passed type', () => {
-    const query = new Query(typeBundle, 'Shop');
-
-    assert.deepEqual(splitQuery(query.toString()), splitQuery('fragment on Shop { }'));
-  });
-
-  test('it can add basic fields', () => {
-    const query = new Query(typeBundle, 'Shop');
-
-    query.addField('name');
-
-    assert.deepEqual(splitQuery(query.toString()), splitQuery('fragment on Shop { name }'));
-  });
-
-  test('it yields an instance of Query representing the type passed to addField', () => {
-    const query = new Query(typeBundle);
-
-    query.addField('shop', {}, (shop) => {
-      assert.ok(Query.prototype.isPrototypeOf(shop));
-    });
-  });
-
-  test('it doesn\'t require query args when using addField or addConnection', () => {
-    const query = new Query(typeBundle);
-    let addFieldCalledCallBack = false;
-
-    query.addField('shop', () => {
-      addFieldCalledCallBack = true;
+  test('constructor taks a typeBundle and a callback which is called with the query\'s SelectionSet', () => {
+    let rootType = null;
+    const query = new Query(typeBundle, (root) => {
+      rootType = root.typeSchema;
+      root.addField('shop', (shop) => {
+        shop.addField('name');
+      });
     });
 
-    assert.ok(addFieldCalledCallBack, 'addField called callback even if args wasn\'t passed');
-  });
-
-  test('it doesn\'t require query args when using addConnection', () => {
-    const query = new Query(typeBundle, 'Shop');
-    let addConnectionCalledCallBack = false;
-
-    query.addConnection('collections', () => {
-      addConnectionCalledCallBack = true;
-    });
-
-    assert.ok(addConnectionCalledCallBack, 'addConnection called callback even if args wasn\'t passed');
-  });
-
-  test('it composes nested querys', () => {
-    const query = new Query(typeBundle);
-
-    query.addField('shop', {}, (shop) => {
-      shop.addField('name');
-    });
-
+    assert.deepEqual(typeBundle.QueryRoot, rootType);
     assert.deepEqual(splitQuery(query.toString()), splitQuery('query { shop { name } }'));
   });
-
-  test('it can attach args to nested nodes', () => {
-    const query = new Query(typeBundle);
-
-    query.addField('product', {id: '1'}, (shop) => {
-      shop.addField('title');
-    });
-
-    assert.deepEqual(splitQuery(query.toString()), splitQuery('query { product (id: "1") { title } }'));
-  });
-
-  test('it adds connections with pagination info', () => {
-    const query = new Query(typeBundle);
-
-    query.addField('shop', {}, (shop) => {
-      shop.addField('name');
-      shop.addConnection('products', {first: 10}, (product) => {
-        product.addField('handle');
-      });
-    });
-
-    assert.deepEqual(splitQuery(query.toString()), splitQuery(`query {
-      shop {
-        name,
-        products (first: 10) {
-          pageInfo {
-            hasNextPage,
-            hasPreviousPage
-          },
-          edges {
-            cursor,
-            node {
-              handle
-            }
-          }
-        }
-      }
-    }`));
-  });
-
-  test('it adds inline fragments', () => {
-    const query = new Query(typeBundle);
-
-    query.addField('shop', {}, (shop) => {
-      shop.addInlineFragmentOn('Shop', (fragment) => {
-        fragment.addField('name');
-      });
-    });
-
-    assert.deepEqual(splitQuery(query.toString()), splitQuery(`query {
-      shop {
-        ... on Shop {
-          name
-        }
-      }
-    }`));
-  });
-
-
 });

--- a/test/selection-set-test.js
+++ b/test/selection-set-test.js
@@ -1,0 +1,126 @@
+import assert from 'assert';
+import {SelectionSet} from '../src/query';
+import typeBundle from '../fixtures/types'; // eslint-disable-line import/no-unresolved
+
+suite('Unit | SelectionSet', () => {
+  const querySplitter = /[\s,]+/;
+
+  function tokens(query) {
+    return query.split(querySplitter);
+  }
+
+  test('it builds sets using the passed type', () => {
+    const set = new SelectionSet(typeBundle, 'Shop');
+
+    assert.deepEqual(typeBundle.Shop, set.typeSchema);
+    assert.deepEqual(tokens(set.toString()), tokens(' { }'));
+  });
+
+  test('it can add basic fields', () => {
+    const set = new SelectionSet(typeBundle, 'Shop');
+
+    set.addField('name');
+
+    assert.deepEqual(tokens(set.toString()), tokens(' { name }'));
+  });
+
+  test('addField yields another instance of SelectionSet representing the type of the field', () => {
+    const set = new SelectionSet(typeBundle, 'QueryRoot');
+
+    set.addField('shop', {}, (shop) => {
+      assert.equal(typeBundle.Shop, shop.typeSchema);
+      assert.ok(SelectionSet.prototype.isPrototypeOf(shop));
+    });
+  });
+
+  test('it doesn\'t require field args when using addField or addConnection', () => {
+    const set = new SelectionSet(typeBundle, 'QueryRoot');
+    let addFieldCalledCallBack = false;
+
+    set.addField('shop', () => {
+      addFieldCalledCallBack = true;
+    });
+
+    assert.ok(addFieldCalledCallBack, 'addField called callback even if args wasn\'t passed');
+  });
+
+  test('it doesn\'t require query args when using addConnection', () => {
+    const set = new SelectionSet(typeBundle, 'Shop');
+    let addConnectionCalledCallBack = false;
+
+    set.addConnection('collections', () => {
+      addConnectionCalledCallBack = true;
+    });
+
+    assert.ok(addConnectionCalledCallBack, 'addConnection called callback even if args wasn\'t passed');
+  });
+
+  test('it composes nested querys', () => {
+    const set = new SelectionSet(typeBundle, 'QueryRoot');
+
+    set.addField('shop', {}, (shop) => {
+      shop.addField('name');
+    });
+
+    assert.deepEqual(tokens(set.toString()), tokens(' { shop { name } }'));
+  });
+
+  test('it can attach args to nested nodes', () => {
+    const set = new SelectionSet(typeBundle, 'QueryRoot');
+
+    set.addField('product', {id: '1'}, (product) => {
+      product.addField('title');
+    });
+
+    assert.deepEqual(tokens(set.toString()), tokens(' { product (id: "1") { title } }'));
+  });
+
+  test('it adds connections with pagination info', () => {
+    const set = new SelectionSet(typeBundle, 'QueryRoot');
+
+    set.addField('shop', {}, (shop) => {
+      shop.addField('name');
+      shop.addConnection('products', {first: 10}, (product) => {
+        product.addField('handle');
+      });
+    });
+
+    assert.deepEqual(tokens(set.toString()), tokens(` {
+      shop {
+        name,
+        products (first: 10) {
+          pageInfo {
+            hasNextPage,
+            hasPreviousPage
+          },
+          edges {
+            cursor,
+            node {
+              handle
+            }
+          }
+        }
+      }
+    }`));
+  });
+
+  test('it adds inline fragments', () => {
+    const set = new SelectionSet(typeBundle, 'QueryRoot');
+
+    set.addField('shop', {}, (shop) => {
+      shop.addInlineFragmentOn('Shop', (fragment) => {
+        fragment.addField('name');
+      });
+    });
+
+    assert.deepEqual(tokens(set.toString()), tokens(` {
+      shop {
+        ... on Shop {
+          name
+        }
+      }
+    }`));
+  });
+
+
+});


### PR DESCRIPTION
@minasmart and @mikkoh please review.

Almost all of what was in `Query` is now in `SelectionSet`, which remains in the same file (query.js) because I'm anticipating a need for cyclic dependencies between this family of types in the near future.

I split the relevant tests out into a new file and made a few small tweaks to them. `Query` is now very small and doesn't do much at all. Its constructor takes a function that gets called with its root `SelectionSet` in the same manner as the callback passed to `addField` & co.

`toQuery` renamed to `toString` because now we have a thing called `Query`.
