### PR TITLE
[FIX] Don't allow warnings for the browser linter

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,9 +5,10 @@
       "template": "mocha",
       "paths": [
         "src/**/*.js",
-        "test/**/*.js",
+        "test/**/*.js"
       ],
-      "file": "test/lint-tests.js"
+      "file": "test/lint-tests.js",
+      "maxWarnings": 0
     }]
   ],
   "env": {
@@ -22,7 +23,7 @@
           "modules": false
         }],
         "es2015-rollup"
-      ],
+      ]
     }
-  },
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "babel-cli": "6.11.4",
     "babel-core": "6.13.2",
     "babel-plugin-add-shopify-header": "1.0.5",
-    "babel-plugin-eslint-test-generator": "1.0.1",
+    "babel-plugin-eslint-test-generator": "1.0.2",
     "babel-plugin-external-helpers": "6.8.0",
     "babel-preset-es2015-rollup": "1.2.0",
     "babel-preset-shopify": "15.0.1",


### PR DESCRIPTION
This incorporates the new functionality recently added to `eslint-test-generator` of having a `maxWarnings` flag on test generators config
