### PR TITLE
refactor addConnection to use addField

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -119,26 +119,18 @@ export class SelectionSet {
    * @param {Function}  [callback] Callback which will return a new query node for the connection added
    */
   addConnection(name, ...paramArgsCallback) {
-    if (this.hasSelectionWithName(name)) {
-      throw new Error(`The connection '${name}' has already been added`);
-    }
-
     const {args, callback} = getArgsAndCallback(paramArgsCallback);
 
-    const fieldDescriptor = descriptorForField(this.typeBundle, name, this.typeSchema.name);
-    const selectionSet = new SelectionSet(this.typeBundle, fieldDescriptor.schema);
-
-    selectionSet.addField('pageInfo', {}, (pageInfo) => {
-      pageInfo.addField('hasNextPage');
-      pageInfo.addField('hasPreviousPage');
+    this.addField(name, args, (connection) => {
+      connection.addField('pageInfo', {}, (pageInfo) => {
+        pageInfo.addField('hasNextPage');
+        pageInfo.addField('hasPreviousPage');
+      });
+      connection.addField('edges', {}, (edges) => {
+        edges.addField('cursor');
+        edges.addField('node', {}, callback);
+      });
     });
-
-    selectionSet.addField('edges', {}, (edges) => {
-      edges.addField('cursor');
-      edges.addField('node', {}, callback);
-    });
-
-    this.selections.push(new Field(name, args, selectionSet));
   }
 
   addInlineFragmentOn(typeName, fieldTypeCb = noop) {

--- a/test/selection-set-test.js
+++ b/test/selection-set-test.js
@@ -135,23 +135,4 @@ suite('Unit | SelectionSet', () => {
       /The field 'name' has already been added/
     );
   });
-
-  test('it cannot add the same connection twice', () => {
-    assert.throws(
-      () => {
-        const set = new SelectionSet(typeBundle, 'QueryRoot');
-
-        set.addField('shop', {}, (shop) => {
-          shop.addConnection('products', {first: 10}, (product) => {
-            product.addField('handle');
-          });
-
-          shop.addConnection('products', {first: 10}, (product) => {
-            product.addField('handle');
-          });
-        });
-      },
-      /The connection 'products' has already been added/
-    );
-  });
 });


### PR DESCRIPTION
@mikkoh and @minasmart please review.

I noticed that `addConnection` was duplicating logic from `addField` instead of being built on top of `addField`. Only behaviour change is that the error message for adding a connection twice with the same name is now the same as for `addField`, which I think is how it should be anyway. I removed the test for the `addConnection` case since it seemed like it was no longer necessary.
