### PR TITLE
Rename test suites to match file names

### DIFF
--- a/test/class-registry-test.js
+++ b/test/class-registry-test.js
@@ -3,7 +3,7 @@ import assert from 'assert';
 import ClassRegistry from '../src/class-registry';
 import GraphModel from '../src/graph-model';
 
-suite('Unit | ClassRegistry', () => {
+suite('class-registry-test', () => {
   test('it returns the defined constructor fot the type', () => {
 
     const registry = new ClassRegistry();

--- a/test/deserialize-object-test.js
+++ b/test/deserialize-object-test.js
@@ -70,7 +70,7 @@ const productFixture = {
   }
 };
 
-suite('Unit | deserializeObject', () => {
+suite('deserialize-object-test', () => {
   test('it creates a GraphModel from the root type', () => {
 
     const graph = deserializeObject(typeBundle, graphFixture.data, 'QueryRoot');

--- a/test/document-test.js
+++ b/test/document-test.js
@@ -3,7 +3,7 @@ import Query from '../src/query';
 import Document from '../src/document';
 import typeBundle from '../fixtures/types'; // eslint-disable-line import/no-unresolved
 
-suite('Unit | Document', () => {
+suite('document-test', () => {
   const querySplitter = /[\s,]+/;
 
   function tokens(query) {

--- a/test/format-args-test.js
+++ b/test/format-args-test.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 import formatArgs from '../src/format-args';
 import _enum from '../src/enum';
 
-suite('Unit | format arguments', () => {
+suite('format-args-test', () => {
   test('it formats args with only scalars', () => {
     const result = formatArgs({int: 1, float: 0.1, string: 'two', boolean: true});
 

--- a/test/graph-model-test.js
+++ b/test/graph-model-test.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import GraphModel from '../src/graph-model';
 
-suite('Unit | GraphModel', () => {
+suite('graph-model-test', () => {
   const attrs = {
     beans: true,
     beanType: 'kidney'

--- a/test/join-test.js
+++ b/test/join-test.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 
 import join from '../src/join';
 
-suite('Unit | join', () => {
+suite('join-test', () => {
   test('it joins fields with a single comma followed by a space', () => {
 
     assert.equal(join('query1', 'query2'), 'query1 query2');

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 import Query from '../src/query';
 import typeBundle from '../fixtures/types'; // eslint-disable-line import/no-unresolved
 
-suite('Unit | Query', () => {
+suite('query-test', () => {
   const querySplitter = /[\s,]+/;
 
   function splitQuery(query) {

--- a/test/query-variables-test.js
+++ b/test/query-variables-test.js
@@ -3,7 +3,7 @@ import Query from '../src/query';
 import variable, {VariableDefinition} from '../src/variable';
 import typeBundle from '../fixtures/types'; // eslint-disable-line import/no-unresolved
 
-suite('Unit | Query Variables', () => {
+suite('query-variables-test', () => {
   const querySplitter = /[\s,]+/;
 
   function tokens(query) {

--- a/test/selection-set-test.js
+++ b/test/selection-set-test.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 import SelectionSet from '../src/selection-set';
 import typeBundle from '../fixtures/types'; // eslint-disable-line import/no-unresolved
 
-suite('Unit | SelectionSet', () => {
+suite('selection-set-test', () => {
   const querySplitter = /[\s,]+/;
 
   function tokens(query) {


### PR DESCRIPTION
@minasmart @mikkoh please review.

Discussed this with @minasmart in person this afternoon: when I first came to this project, it wasn't obvious to me how the test suite names mapped to file names for me to find the source of failing tests. This PR renames the suites to match their containing file names (minus `.js`) to make things a bit more clear.