### PR TITLE
bump graphql-js-schema to 0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Shopify Inc.",
   "dependencies": {},
   "devDependencies": {
-    "@shopify/graphql-js-schema": "0.1.0",
+    "@shopify/graphql-js-schema": "0.2.2",
     "babel": "6.5.2",
     "babel-cli": "6.18.0",
     "babel-core": "6.18.0",

--- a/src/schema-for-type.js
+++ b/src/schema-for-type.js
@@ -1,5 +1,5 @@
 export default function schemaForType(typeBundle, typeName) {
-  const type = typeBundle[typeName];
+  const type = typeBundle.types[typeName];
 
   if (type) {
     return type;

--- a/test/document-test.js
+++ b/test/document-test.js
@@ -24,7 +24,7 @@ suite('document-test', () => {
       rootType = root.typeSchema;
     });
 
-    assert.deepEqual(typeBundle.QueryRoot, rootType);
+    assert.deepEqual(typeBundle.types.QueryRoot, rootType);
   });
 
   test('it can stringify a single query document', () => {

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -22,7 +22,7 @@ suite('query-test', () => {
       buildQuery(root);
     });
 
-    assert.deepEqual(typeBundle.QueryRoot, rootType);
+    assert.deepEqual(typeBundle.types.QueryRoot, rootType);
     assert.deepEqual(splitQuery(query.toString()), splitQuery('query { shop { name } }'));
   });
 
@@ -33,7 +33,7 @@ suite('query-test', () => {
       buildQuery(root);
     });
 
-    assert.deepEqual(typeBundle.QueryRoot, rootType);
+    assert.deepEqual(typeBundle.types.QueryRoot, rootType);
     assert.deepEqual(splitQuery(query.toString()), splitQuery('query myQuery { shop { name } }'));
   });
 

--- a/test/selection-set-test.js
+++ b/test/selection-set-test.js
@@ -13,7 +13,7 @@ suite('selection-set-test', () => {
   test('it builds sets using the passed type', () => {
     const set = new SelectionSet(typeBundle, 'Shop');
 
-    assert.deepEqual(typeBundle.Shop, set.typeSchema);
+    assert.deepEqual(typeBundle.types.Shop, set.typeSchema);
     assert.deepEqual(tokens(set.toString()), tokens(' { }'));
   });
 
@@ -44,7 +44,7 @@ suite('selection-set-test', () => {
       });
     });
     assert.equal(typeBundle, shopBuilder.typeBundle);
-    assert.equal(typeBundle.Shop, shopBuilder.typeSchema);
+    assert.equal(typeBundle.types.Shop, shopBuilder.typeSchema);
   });
 
   test('it doesn\'t require field args when using add or addConnection', () => {


### PR DESCRIPTION
@minasmart please review.

Bumps the version and accommodates the newly nested `.types`.