### PR TITLE
Enable commonjs plugin sourcemaps

### DIFF
--- a/scripts/rollup-tests.js
+++ b/scripts/rollup-tests.js
@@ -20,8 +20,7 @@ function envRollupInfo({browser, withDependencyTracking}) {
       ]
     }),
     commonjs({
-      include: 'node_modules/**',
-      sourceMap: false
+      include: 'node_modules/**'
     }),
     nodeResolve({
       jsnext: true,


### PR DESCRIPTION
Disabling `sourceMap` resulted in this warning:

> Sourcemap is likely to be incorrect: a plugin ('commonjs') was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help