### PR TITLE
[FIX] Actually run the lint tests.

### DIFF
--- a/scripts/rollup-plugin-eslint-test-generator.js
+++ b/scripts/rollup-plugin-eslint-test-generator.js
@@ -37,9 +37,12 @@ function getNewLints(files, cache) {
 }
 
 function generateLintBundle(lints) {
-  const lintTests = Object.keys(lints).sort().map((fileName) => {
-    return lints[fileName].lint;
-  }).join('\n');
+  const lintTests = Object.keys(lints)
+    .sort()
+    .map((fileName) => {
+      return lints[fileName].lint;
+    })
+    .join('\n');
 
   return `import assert from 'assert';
 suite('lint-tests', function() {
@@ -52,8 +55,9 @@ const lintResultCache = {};
 module.exports = function(options = {}) {
   const filter = createFilter(options.include, options.exclude);
   const files = options.paths
-    .reduce((fileAcc, lintPath) => fileAcc.concat(klawSync(lintPath, {nodir: true})), [])
-    .filter((file) => file.path.endsWith('.js'))
+    .reduce((fileAcc, lintPath) => fileAcc.concat(klawSync(lintPath)), [])
+    .map((file) => file.path)
+    .filter((file) => file.endsWith('.js'))
     .filter((file) => filter(file));
 
   return {


### PR DESCRIPTION
After upgrading `fs-extra` only to find out that `walkSync` had been extracted into its own package called `klawSync`, I didn't actually verify that I was invoking things properly. Now we're properly building a file list for linting again