### PR TITLE
[FIX] Throw informative error in SelectionSet if field is not found

### DIFF
--- a/src/selection-set.js
+++ b/src/selection-set.js
@@ -229,6 +229,10 @@ class SelectionSetBuilder {
     let {selectionSet} = parsedArgs;
 
     if (!selectionSet) {
+      if (!this.typeSchema.fieldBaseTypes[name]) {
+        throw new Error(`No field of name "${name}" found on type "${this.typeSchema.name}" in schema`);
+      }
+
       const fieldBaseType = schemaForType(this.typeBundle, this.typeSchema.fieldBaseTypes[name]);
 
       selectionSet = new SelectionSet(this.typeBundle, fieldBaseType, callback);

--- a/test/selection-set-test.js
+++ b/test/selection-set-test.js
@@ -282,4 +282,14 @@ suite('selection-set-test', () => {
     assert.notEqual(set.selections[0].args.fakeArg, args.fakeArg);
     assert.equal(set.selections[0].args.fakeArg.nestedVariable, args.fakeArg.nestedVariable);
   });
+
+  test('it throws an informative error if the field does not exist in the schema', () => {
+    assert.throws(() => {
+      new SelectionSet(typeBundle, 'QueryRoot', (root) => {
+        root.add('shop', (shop) => {
+          shop.add('spaghetti');
+        });
+      });
+    }, /No field of name "spaghetti" found on type "Shop" in schema/);
+  });
 });


### PR DESCRIPTION
Previously, building a query like 
```javascript
client.query((root) => {
  root.add('shop', (shop) => {
    shop.add('notInSchema');
  });
});
```
would throw an error with `No type of undefined found in schema` which made it hard to find the exact field that wasn't in the schema. 
This PR adds an extra error check so that the error will instead be `No type of notInSchema on Shop found in schema`.