### PR TITLE
[FIX] Check for enums properly when deep freeze copying

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -8,6 +8,7 @@ import httpFetcher from './http-fetcher';
 
 export {default as GraphModel} from './graph-model';
 export {ClassRegistry};
+export {default as _enum} from './enum';
 
 export default class Client {
   constructor(typeBundle, {url, fetcherOptions, fetcher, registry = new ClassRegistry()}) {

--- a/src/enum.js
+++ b/src/enum.js
@@ -8,7 +8,7 @@ export class Enum {
   }
 
   valueOf() {
-    return this.key;
+    return this.key.valueOf();
   }
 }
 

--- a/test/deep-freeze-copy-except-test.js
+++ b/test/deep-freeze-copy-except-test.js
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import deepFreezeCopyExcept from '../src/deep-freeze-copy-except';
+import {Enum} from '../src/enum';
 
 suite('deep-freeze-copy-except-test', () => {
   test('it makes a deep copy of nested objects and arrays, without copying values that satisfy the given predicate', () => {
@@ -7,7 +8,8 @@ suite('deep-freeze-copy-except-test', () => {
       a1: [
         {
           b1: Object.freeze({}),
-          b2: 'b2'
+          b2: 'b2',
+          b3: new Enum('b3')
         }
       ],
       a2: 'a2'
@@ -19,11 +21,13 @@ suite('deep-freeze-copy-except-test', () => {
     assert.notEqual(copy.a1, original.a1);
     assert.notEqual(copy.a1[0], original.a1[0]);
     assert.equal(copy.a1[0].b1, original.a1[0].b1);
+    assert.equal(copy.a1[0].b3, original.a1[0].b3);
     assert.ok(!Object.isFrozen(original.a1));
     assert.ok(!Object.isFrozen(original));
     assert.ok(!Object.isFrozen(original.a1[0]));
     assert.ok(Object.isFrozen(copy));
     assert.ok(Object.isFrozen(copy.a1));
     assert.ok(Object.isFrozen(copy.a1[0]));
+    assert.ok(Enum.prototype.isPrototypeOf(copy.a1[0].b3), 'enums remain as Enum types');
   });
 });

--- a/test/is-object-test.js
+++ b/test/is-object-test.js
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import isObject from '../src/is-object';
 import Scalar from '../src/scalar';
+import _enum from '../src/enum';
 
 suite('is-object-test', () => {
   test('it returns true for POJOs', () => {
@@ -40,5 +41,9 @@ suite('is-object-test', () => {
 
   test('it handles undefined values', () => {
     assert.equal(isObject(), false);
+  });
+
+  test('it returns false for enums', () => {
+    assert.equal(isObject(_enum('enum')), false);
   });
 });


### PR DESCRIPTION
`isObject()` returned true for enums, so after calling `deepFreezeCopyExcept()` when building the `SelectionSet`, any `Enum` was converted to a plain object. Thus, `toString()` on queries gave the wrong result.

This PR fixes the `isObject` type checking so enums are copied properly and also exports enums so we can access them from `js-buy-sdk` to sort query results.