### PR TITLE
Remove unnecessary toString calls

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -13,7 +13,7 @@ function hasAnonymousOperations(operations) {
 }
 
 function hasDuplicateOperationNames(operations) {
-  const names = operations.map((operation) => operation.name.toString());
+  const names = operations.map((operation) => operation.name);
 
   return names.reduce((hasDuplicates, name, index) => {
     return hasDuplicates || names.indexOf(name) !== index;
@@ -51,7 +51,7 @@ export default class Document {
   }
 
   toString() {
-    return join(this.definitions.map((definition) => definition.toString()));
+    return join(this.definitions);
   }
 
   addOperation(operationType, ...args) {

--- a/src/operation.js
+++ b/src/operation.js
@@ -39,11 +39,7 @@ class VariableDefinitions {
       return '';
     }
 
-    const variableDefinitionsStrings = this.variableDefinitions.map((variableDefinition) => {
-      return variableDefinition.toVariableDefinitionString();
-    });
-
-    return ` (${join(variableDefinitionsStrings)}) `;
+    return ` (${join(this.variableDefinitions)}) `;
   }
 }
 
@@ -72,6 +68,6 @@ export default class Operation {
   toString() {
     const nameString = (this.name) ? ` ${this.name}` : '';
 
-    return `${this.operationType}${nameString}${this.variableDefinitions.toString()}${this.selectionSet.toString()}`;
+    return `${this.operationType}${nameString}${this.variableDefinitions}${this.selectionSet}`;
   }
 }

--- a/src/selection-set.js
+++ b/src/selection-set.js
@@ -47,7 +47,7 @@ export class Field {
   toString() {
     const aliasPrefix = this.alias ? `${this.alias}: ` : '';
 
-    return `${aliasPrefix}${this.name}${formatArgs(this.args)}${this.selectionSet.toString()}`;
+    return `${aliasPrefix}${this.name}${formatArgs(this.args)}${this.selectionSet}`;
   }
 }
 
@@ -62,7 +62,7 @@ export class InlineFragment extends Spread {
     Object.freeze(this);
   }
   toString() {
-    return `... on ${this.typeName}${this.selectionSet.toString()}`;
+    return `... on ${this.typeName}${this.selectionSet}`;
   }
 }
 
@@ -89,7 +89,7 @@ export class FragmentDefinition {
   }
 
   toString() {
-    return `fragment ${this.name} on ${this.typeName} ${this.selectionSet.toString()}`;
+    return `fragment ${this.name} on ${this.typeName} ${this.selectionSet}`;
   }
 }
 
@@ -186,11 +186,7 @@ export default class SelectionSet {
     if (this.typeSchema.kind === 'SCALAR') {
       return '';
     } else {
-      const commaDelimitedSelections = join(this.selections.map((selection) => {
-        return selection.toString();
-      }));
-
-      return ` { ${commaDelimitedSelections} }`;
+      return ` { ${join(this.selections)} }`;
     }
   }
 }

--- a/src/variable.js
+++ b/src/variable.js
@@ -12,7 +12,7 @@ export class VariableDefinition {
     return `$${this.name}`;
   }
 
-  toVariableDefinitionString() {
+  toString() {
     const defaultValueString = this.defaultValue ? ` = ${formatInputValue(this.defaultValue)}` : '';
 
     return `$${this.name}:${this.type}${defaultValueString}`;

--- a/test/variable-test.js
+++ b/test/variable-test.js
@@ -25,15 +25,15 @@ suite('variable-test', () => {
     assert.equal(variableId.toInputValueString(), '$id');
   });
 
-  test('toVariableDefinitionString returns a formatted string with its name and type', () => {
+  test('toString returns a formatted string with its name and type', () => {
     const variableId = variable('id', 'ID!');
 
-    assert.equal(variableId.toVariableDefinitionString(), '$id:ID!');
+    assert.equal(variableId.toString(), '$id:ID!');
   });
 
-  test('toVariableDefinitionString returns a formatted string with its name, type, and defaultValue', () => {
+  test('toString returns a formatted string with its name, type, and defaultValue', () => {
     const variableId = variable('id', 'ID!', '123');
 
-    assert.equal(variableId.toVariableDefinitionString(), '$id:ID! = "123"');
+    assert.equal(variableId.toString(), '$id:ID! = "123"');
   });
 });


### PR DESCRIPTION
Not a huge deal, but noticed some places where we explicitly calling `toString()` when it's called anyway in the context of a string.