### PR TITLE
[FIX] SelectionSet toString() for enum fields

### DIFF
--- a/src/selection-set.js
+++ b/src/selection-set.js
@@ -183,7 +183,7 @@ export default class SelectionSet {
   }
 
   toString() {
-    if (this.typeSchema.kind === 'SCALAR') {
+    if (this.typeSchema.kind === 'SCALAR' || this.typeSchema.kind === 'ENUM') {
       return '';
     } else {
       return ` { ${join(this.selections)} }`;

--- a/test/selection-set-test.js
+++ b/test/selection-set-test.js
@@ -292,4 +292,33 @@ suite('selection-set-test', () => {
       });
     }, /No field of name "spaghetti" found on type "Shop" in schema/);
   });
+
+  test('it can add enum fields', () => {
+    const set = new SelectionSet(typeBundle, 'QueryRoot', (root) => {
+      root.add('product', (product) => {
+        product.addConnection('variants', (variant) => {
+          variant.add('weightUnit'); // enum field
+        });
+      });
+    });
+
+    assert.deepEqual(tokens(set.toString()), tokens(`{
+      product {
+        id,
+        variants {
+          pageInfo {
+            hasNextPage,
+            hasPreviousPage
+          },
+          edges {
+            cursor,
+            node {
+              id,
+              weightUnit
+            }
+          }
+        }
+      }
+    }`));
+  });
 });


### PR DESCRIPTION
`toString()` would add an extra `{ }` to enum fields in the query, so it would look like
``` graphql
{
  node(id: "gid://shopify/Product/8631749576") {
    ... on Product {
      id
      variants (first: 10) {
        edges {
          node {
            weightUnit { } # enum field with extra brackets
          }
        }
      }
    }
  }
}
```

This PR adds an extra check to the condition so that the extra brackets aren't added.