### PR TITLE
[FEATURE] Expose decode function

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -9,6 +9,7 @@ import httpFetcher from './http-fetcher';
 export {default as GraphModel} from './graph-model';
 export {ClassRegistry};
 export {default as _enum} from './enum';
+export {default as decode} from './decode';
 
 export default class Client {
   constructor(typeBundle, {url, fetcherOptions, fetcher, registry = new ClassRegistry()}) {


### PR DESCRIPTION
Expose `decode` so we can use the function in Shopify/js-buy-sdk#317 and elsewhere when needed.