### PR TITLE
[FEATURE] Move fetchAllPages to graphql-js-client

### DIFF
--- a/test/client-fetch-all-pages-test.js
+++ b/test/client-fetch-all-pages-test.js
@@ -25,18 +25,24 @@ suite('client-fetch-all-pages-test', () => {
   test('it fetches until hasNextPage is false', () => {
     const models = [{hasNextPage: true}];
 
-    return mockClient.fetchAllPages(models, 1).then(() => {
-      assert.equal(models.length, 3);
-      assert.equal(models[2].hasNextPage, false, 'last model has no more pages');
-      assert.ok(models.slice(0, 2).every((model) => {
+    return mockClient.fetchAllPages(models, {pageSize: 1}).then((result) => {
+      assert.equal(result.length, 3);
+      assert.equal(result[2].hasNextPage, false, 'last model has no more pages');
+      assert.ok(result.slice(0, 2).every((model) => {
         return model.hasNextPage;
       }), 'models before the last model have next pages');
     });
   });
 
-  test('it returns undefined if there is nothing to paginate on', () => {
-    assert.equal(typeof mockClient.fetchAllPages([]), 'undefined');
-    assert.equal(typeof mockClient.fetchAllPages([{hasNextPage: false}]), 'undefined');
+  test('it returns an empty array if there is nothing to paginate on', () => {
+    return mockClient.fetchAllPages([], {pageSize: 1}).then((result) => {
+      assert.deepEqual(result, []);
+    });
+  });
+
+  test('it returns the original array if it already has all pages', () => {
+    return mockClient.fetchAllPages([{hasNextPage: true}, {hasNextPage: false}], {pageSize: 1}).then((result) => {
+      assert.deepEqual(result, [{hasNextPage: true}, {hasNextPage: false}]);
+    });
   });
 });
-


### PR DESCRIPTION
Moved the logic for fetching all pages from `js-buy-sdk`.

Github issue: https://github.com/Shopify/storefront-api-team-projects/issues/64 