### PR TITLE
[FIX] Add check to only add refetch query if the node is not null

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -11,6 +11,64 @@
       "types": [
         {
           "kind": "OBJECT",
+          "name": "Checkout",
+          "description": null,
+          "fields": [
+            {
+              "name": "shippingAddress",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "MailingAddress",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "MailingAddress",
+          "description": null,
+          "fields": [
+            {
+              "name": "address1",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "PaginatedScalarEdge",
           "description": null,
           "fields": [
@@ -441,6 +499,16 @@
             {
               "kind": "OBJECT",
               "name": "ProductVariant",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Checkout",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "MailingAddress",
               "ofType": null
             }
           ]

--- a/src/decode.js
+++ b/src/decode.js
@@ -78,7 +78,7 @@ function decodeContext(context, transformers) {
 }
 
 function generateRefetchQueries(context, value) {
-  if (isNodeContext(context)) {
+  if (isValue(value) && isNodeContext(context)) {
     value.refetchQuery = function() {
       return new Query(context.selection.selectionSet.typeBundle, (root) => {
         root.add('node', {args: {id: context.responseData.id}}, (node) => {

--- a/test/decode-refetch-query-test.js
+++ b/test/decode-refetch-query-test.js
@@ -77,4 +77,29 @@ suite('decode-refetch-query-test', () => {
       }
     }`));
   });
+
+  test('Null nodes remain null and do not generate a refetch query', () => {
+    const nullNodeFixture = {
+      data: {
+        node: {
+          __typename: 'Checkout',
+          shippingAddress: null
+        }
+      }
+    };
+
+    const checkoutQuery = new Query(typeBundle, (root) => {
+      root.add('node', {args: {id: 'gid://shopify/Checkout/1'}}, (node) => {
+        node.addInlineFragmentOn('Checkout', (checkout) => {
+          checkout.add('shippingAddress', (shippingAddress) => {
+            shippingAddress.add('address1');
+          });
+        });
+      });
+    });
+
+    const shippingAddressNode = decode(checkoutQuery, nullNodeFixture.data).node.shippingAddress;
+
+    assert.equal(Object.prototype.toString.call(shippingAddressNode), '[object Null]');
+  });
 });


### PR DESCRIPTION
Since `MailingAddress` and `Order` are nodes and [can be null](https://github.com/Shopify/shopify/blob/master/db/graphql/storefront_schema.graphql#L25), we need to add a null check before attempting to add the refetchQuery otherwise it will throw an error (i.e. `value` is null).