### PR TITLE
Use responseKey to check for conflicts instead of name

### DIFF
--- a/src/selection-set.js
+++ b/src/selection-set.js
@@ -198,9 +198,9 @@ class SelectionSetBuilder {
     this.selections = selections;
   }
 
-  hasSelectionWithName(name) {
+  hasSelectionWithResponseKey(responseKey) {
     return this.selections.some((field) => {
-      return field.name === name;
+      return field.responseKey === responseKey;
     });
   }
 
@@ -213,8 +213,8 @@ class SelectionSetBuilder {
       selection = selectionOrFieldName;
     }
 
-    if (selection.name && this.hasSelectionWithName(selection.name)) {
-      throw new Error(`The field '${selection.name}' has already been added`);
+    if (selection.responseKey && this.hasSelectionWithResponseKey(selection.responseKey)) {
+      throw new Error(`The field name or alias '${selection.responseKey}' has already been added.`);
     }
     this.selections.push(selection);
   }

--- a/test/selection-set-test.js
+++ b/test/selection-set-test.js
@@ -179,7 +179,49 @@ suite('selection-set-test', () => {
           });
         });
       },
-      /The field 'name' has already been added/
+      /The field name or alias 'name' has already been added/
+    );
+  });
+
+  test('it cannot use the same alias twice', () => {
+    assert.throws(
+      () => {
+        new SelectionSet(typeBundle, 'QueryRoot', (root) => {
+          root.add('shop', (shop) => {
+            shop.add('name', {alias: 'theNameOfTheShop'});
+            shop.add('name', {alias: 'theNameOfTheShop'});
+          });
+        });
+      },
+      /The field name or alias 'theNameOfTheShop' has already been added/
+    );
+  });
+
+  test('it cannot add an alias with the same name as a field', () => {
+    assert.throws(
+      () => {
+        new SelectionSet(typeBundle, 'QueryRoot', (root) => {
+          root.add('shop', (shop) => {
+            shop.add('name');
+            shop.add('description', {alias: 'name'});
+          });
+        });
+      },
+      /The field name or alias 'name' has already been added/
+    );
+  });
+
+  test('it cannot add a field with the same name as an alias', () => {
+    assert.throws(
+      () => {
+        new SelectionSet(typeBundle, 'QueryRoot', (root) => {
+          root.add('shop', (shop) => {
+            shop.add('description', {alias: 'name'});
+            shop.add('name');
+          });
+        });
+      },
+      /The field name or alias 'name' has already been added/
     );
   });
 
@@ -241,6 +283,15 @@ suite('selection-set-test', () => {
     });
 
     assert.deepEqual(tokens(set.toString()), tokens('{ theNameOfTheShop: name }'));
+  });
+
+  test('it can add fields with the same name, but different aliases', () => {
+    const set = new SelectionSet(typeBundle, 'Shop', (shop) => {
+      shop.add('name', {alias: 'theNameOfTheShop'});
+      shop.add('name', {alias: 'alsoTheNameOfTheShop'});
+    });
+
+    assert.deepEqual(tokens(set.toString()), tokens('{ theNameOfTheShop: name, alsoTheNameOfTheShop: name }'));
   });
 
   test('field.responseKey === field.alias when alias is present', () => {


### PR DESCRIPTION
If you added the same field with a different alias (see the last test added), it would yell at you.
Use responseKey instead of name to check for conflicts so it will yell at you for the right reasons. 