### PR TITLE
Switch from jsnext:main to module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.2",
   "description": "Feature light client library for fetching resources via GraphQL",
   "main": "index.js",
-  "jsnext:main": "index.es.js",
+  "module": "index.es.js",
   "license": "MIT",
   "author": "Shopify Inc.",
   "dependencies": {},

--- a/scripts/rollup-tests.js
+++ b/scripts/rollup-tests.js
@@ -23,8 +23,8 @@ function envRollupInfo({browser, withDependencyTracking}) {
       include: 'node_modules/**'
     }),
     nodeResolve({
-      jsnext: true,
       main: true,
+      module: true,
       preferBuiltins: !browser
     }),
     multiEntry({


### PR DESCRIPTION
`module` supersedes `jsnext:main`.

See https://github.com/rollup/rollup/wiki/pkg.module