### PR TITLE
Update installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,13 @@ Feature light client library for fetching resources via GraphQL
 - [License](http://github.com/Shopify/graphql-js-client/blob/master/LICENSE.md)
 
 ## Installation
+**With Yarn:**
 ```bash
 $ yarn add graphql-js-client
+```
+**With NPM:**
+```bash
+$ npm install graphql-js-client
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Feature light client library for fetching resources via GraphQL
 
 ## Installation
 ```bash
-$ yarn install graphql-js-client
+$ yarn add graphql-js-client
 ```
 
 ## Examples


### PR DESCRIPTION
yarn uses `add` to add packages (https://yarnpkg.com/en/docs/cli/add) instead of `install`

Should we provide the NPM installation command as well to stay consistent with https://github.com/Shopify/graphql-js-schema/ and https://github.com/Shopify/graphql-js-schema-fetch/?