### PR TITLE
[FEATURE] normalize profiling

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,7 @@ if (process.env.BUILD_MODE === 'production') {
   entry = 'src/client.js';
 
   plugins.push(remap({
-    originalPath: './src/track-type-dependency',
+    originalPath: './src/profile-schema-usage',
     targetPath: './src/noop'
   }));
 

--- a/scripts/rollup-tests.js
+++ b/scripts/rollup-tests.js
@@ -38,7 +38,7 @@ function envRollupInfo({browser, withDependencyTracking}) {
   // eslint-disable-next-line no-process-env
   if (!withDependencyTracking) {
     plugins.unshift(remap({
-      originalPath: './src/track-type-dependency',
+      originalPath: './src/profile-schema-usage',
       targetPath: './src/noop'
     }));
   }

--- a/src/client-dev.js
+++ b/src/client-dev.js
@@ -1,5 +1,5 @@
 import Client from './client';
-import {resetTracker, startTracking, pauseTracking, trackedTypes, trackedFields, printTypes} from './track-type-dependency';
+import {resetTracker, startTracking, pauseTracking, captureTypeProfile, captureProfile} from './track-type-dependency';
 
 export {default as GraphModel} from './graph-model';
 export {default as ClassRegistry} from './class-registry';
@@ -9,9 +9,8 @@ Object.assign(Client, {
   resetTracker,
   startTracking,
   pauseTracking,
-  trackedTypes,
-  trackedFields,
-  printTypes
+  captureTypeProfile,
+  captureProfile
 });
 
 export default Client;

--- a/src/client-dev.js
+++ b/src/client-dev.js
@@ -1,14 +1,14 @@
 import Client from './client';
-import {resetTracker, startTracking, pauseTracking, captureTypeProfile, captureProfile} from './track-type-dependency';
+import {resetProfiler, startProfiling, pauseProfiling, captureTypeProfile, captureProfile} from './profile-schema-usage';
 
 export {default as GraphModel} from './graph-model';
 export {default as ClassRegistry} from './class-registry';
 export {default as decode} from './decode';
 
 Object.assign(Client, {
-  resetTracker,
-  startTracking,
-  pauseTracking,
+  resetProfiler,
+  startProfiling,
+  pauseProfiling,
   captureTypeProfile,
   captureProfile
 });

--- a/src/profile-schema-usage.js
+++ b/src/profile-schema-usage.js
@@ -1,8 +1,8 @@
 let profile = {};
-let tracking = false;
+let profiling = false;
 
 function trackTypeDependency(typeName) {
-  if (!tracking) {
+  if (!profiling) {
     return;
   }
 
@@ -10,24 +10,24 @@ function trackTypeDependency(typeName) {
 }
 
 function trackFieldDependency(typeName, fieldName) {
-  if (!tracking) {
+  if (!profiling) {
     return;
   }
 
   profile[typeName][fieldName] = true;
 }
 
-export function resetTracker() {
+export function resetProfiler() {
   profile = {};
-  tracking = false;
+  profiling = false;
 }
 
-export function startTracking() {
-  tracking = true;
+export function startProfiling() {
+  profiling = true;
 }
 
-export function pauseTracking() {
-  tracking = false;
+export function pauseProfiling() {
+  profiling = false;
 }
 
 export function captureTypeProfile() {
@@ -42,6 +42,6 @@ export function captureProfile() {
   }, {});
 }
 
-const Tracker = {trackTypeDependency, trackFieldDependency};
+const Profiler = {trackTypeDependency, trackFieldDependency};
 
-export default Tracker;
+export default Profiler;

--- a/src/selection-set.js
+++ b/src/selection-set.js
@@ -4,9 +4,9 @@ import schemaForType from './schema-for-type';
 import formatArgs from './format-args';
 import noop from './noop';
 import {isVariable} from './variable';
-import Tracker from './track-type-dependency';
+import Profiler from './profile-schema-usage';
 
-const {trackTypeDependency, trackFieldDependency} = Tracker;
+const {trackTypeDependency, trackFieldDependency} = Profiler;
 
 function parseFieldCreationArgs(creationArgs) {
   let callback = noop;

--- a/src/track-type-dependency.js
+++ b/src/track-type-dependency.js
@@ -1,5 +1,4 @@
-let types = {};
-let fields = {};
+let profile = {};
 let tracking = false;
 
 function trackTypeDependency(typeName) {
@@ -7,7 +6,7 @@ function trackTypeDependency(typeName) {
     return;
   }
 
-  types[typeName] = true;
+  profile[typeName] = profile[typeName] || {};
 }
 
 function trackFieldDependency(typeName, fieldName) {
@@ -15,16 +14,11 @@ function trackFieldDependency(typeName, fieldName) {
     return;
   }
 
-  if (!fields[typeName]) {
-    fields[typeName] = {};
-  }
-
-  fields[typeName][fieldName] = true;
+  profile[typeName][fieldName] = true;
 }
 
 export function resetTracker() {
-  types = {};
-  fields = {};
+  profile = {};
   tracking = false;
 }
 
@@ -36,18 +30,13 @@ export function pauseTracking() {
   tracking = false;
 }
 
-export function trackedTypes() {
-  return Object.keys(types).sort();
+export function captureTypeProfile() {
+  return Object.keys(profile).sort();
 }
 
-export function printTypes() {
-  // eslint-disable-next-line
-  console.log(trackedTypes().join());
-}
-
-export function trackedFields() {
-  return Object.getOwnPropertyNames(fields).reduce((acc, key) => {
-    acc[key] = Object.getOwnPropertyNames(fields[key]);
+export function captureProfile() {
+  return Object.getOwnPropertyNames(profile).reduce((acc, typeName) => {
+    acc[typeName] = Object.getOwnPropertyNames(profile[typeName]);
 
     return acc;
   }, {});

--- a/test/track-field-dependency-test.js
+++ b/test/track-field-dependency-test.js
@@ -1,15 +1,15 @@
 import assert from 'assert';
 import Query from '../src/query';
 import typeBundle from '../fixtures/types'; // eslint-disable-line import/no-unresolved
-import {resetTracker, startTracking, pauseTracking, captureProfile} from '../src/track-type-dependency';
+import {resetProfiler, startProfiling, pauseProfiling, captureProfile} from '../src/profile-schema-usage';
 
 suite('track-field-dependency-test', () => {
   setup(() => {
-    resetTracker();
+    resetProfiler();
   });
 
   test('it reports the fields used in a query', () => {
-    startTracking();
+    startProfiling();
 
     // eslint-disable-next-line no-new
     new Query(typeBundle, (root) => {
@@ -66,8 +66,8 @@ suite('track-field-dependency-test', () => {
     });
   });
 
-  test('it pauses tracking when `pauseTracking` is called', () => {
-    startTracking();
+  test('it pauses tracking when `pauseProfiling` is called', () => {
+    startProfiling();
 
     // eslint-disable-next-line no-new
     new Query(typeBundle, (root) => {
@@ -76,7 +76,7 @@ suite('track-field-dependency-test', () => {
       });
     });
 
-    pauseTracking();
+    pauseProfiling();
 
     // eslint-disable-next-line no-new
     new Query(typeBundle, (root) => {
@@ -91,7 +91,7 @@ suite('track-field-dependency-test', () => {
       });
     });
 
-    startTracking();
+    startProfiling();
 
     // eslint-disable-next-line no-new
     new Query(typeBundle, (root) => {
@@ -117,9 +117,9 @@ suite('track-field-dependency-test', () => {
   });
 
   test('it stops tracking when `resetTypes` is called (returning the tracker to it\'s initial state.', () => {
-    startTracking();
+    startProfiling();
 
-    resetTracker();
+    resetProfiler();
 
     // eslint-disable-next-line no-new
     new Query(typeBundle, (root) => {

--- a/test/track-field-dependency-test.js
+++ b/test/track-field-dependency-test.js
@@ -1,14 +1,14 @@
 import assert from 'assert';
 import Query from '../src/query';
 import typeBundle from '../fixtures/types'; // eslint-disable-line import/no-unresolved
-import {resetTracker, startTracking, pauseTracking, trackedFields} from '../src/track-type-dependency';
+import {resetTracker, startTracking, pauseTracking, captureProfile} from '../src/track-type-dependency';
 
 suite('track-field-dependency-test', () => {
   setup(() => {
     resetTracker();
   });
 
-  test('it reports the types used in a query', () => {
+  test('it reports the fields used in a query', () => {
     startTracking();
 
     // eslint-disable-next-line no-new
@@ -24,7 +24,11 @@ suite('track-field-dependency-test', () => {
       });
     });
 
-    assert.deepEqual(trackedFields(), {
+    assert.deepEqual(captureProfile(), {
+      Boolean: [],
+      ID: [],
+      Money: [],
+      String: [],
       QueryRoot: [
         'shop'
       ],
@@ -96,7 +100,9 @@ suite('track-field-dependency-test', () => {
       });
     });
 
-    assert.deepEqual(trackedFields(), {
+    assert.deepEqual(captureProfile(), {
+      ID: [],
+      String: [],
       QueryRoot: [
         'shop',
         'node'
@@ -122,6 +128,6 @@ suite('track-field-dependency-test', () => {
       });
     });
 
-    assert.deepEqual(trackedFields(), {});
+    assert.deepEqual(captureProfile(), {});
   });
 });

--- a/test/track-type-dependecy-test.js
+++ b/test/track-type-dependecy-test.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import Query from '../src/query';
 import typeBundle from '../fixtures/types'; // eslint-disable-line import/no-unresolved
-import {resetTracker, startTracking, pauseTracking, trackedTypes, printTypes} from '../src/track-type-dependency';
+import {resetTracker, startTracking, pauseTracking, captureTypeProfile} from '../src/track-type-dependency';
 
 suite('track-type-dependency-test', () => {
   setup(() => {
@@ -24,7 +24,7 @@ suite('track-type-dependency-test', () => {
       });
     });
 
-    assert.deepEqual(trackedTypes(), [
+    assert.deepEqual(captureTypeProfile(), [
       'Boolean',
       'ID',
       'Money',
@@ -75,7 +75,7 @@ suite('track-type-dependency-test', () => {
       });
     });
 
-    assert.deepEqual(trackedTypes(), [
+    assert.deepEqual(captureTypeProfile(), [
       'ID',
       'Node',
       'QueryRoot',
@@ -96,7 +96,7 @@ suite('track-type-dependency-test', () => {
 
     resetTracker();
 
-    assert.deepEqual(trackedTypes(), []);
+    assert.deepEqual(captureTypeProfile(), []);
   });
 
   test('it stops tracking when `resetTypes` is called (returning the tracker to it\'s initial state.', () => {
@@ -111,38 +111,6 @@ suite('track-type-dependency-test', () => {
       });
     });
 
-    assert.deepEqual(trackedTypes(), []);
-  });
-
-  test('it logs the tracked types when `printTypes` is called', () => {
-    startTracking();
-
-    // eslint-disable-next-line no-new
-    new Query(typeBundle, (root) => {
-      root.add('shop', (shop) => {
-        shop.add('name');
-      });
-    });
-
-    let loggedTypes;
-
-    // eslint-disable-next-line
-    const originalLog = console.log;
-
-    // eslint-disable-next-line
-    console.log = function (types) {
-      loggedTypes = types;
-    };
-
-    printTypes();
-
-    // eslint-disable-next-line
-    console.log = originalLog;
-
-    assert.deepEqual(loggedTypes, [
-      'QueryRoot',
-      'Shop',
-      'String'
-    ].join());
+    assert.deepEqual(captureTypeProfile(), []);
   });
 });

--- a/test/track-type-dependecy-test.js
+++ b/test/track-type-dependecy-test.js
@@ -1,15 +1,15 @@
 import assert from 'assert';
 import Query from '../src/query';
 import typeBundle from '../fixtures/types'; // eslint-disable-line import/no-unresolved
-import {resetTracker, startTracking, pauseTracking, captureTypeProfile} from '../src/track-type-dependency';
+import {resetProfiler, startProfiling, pauseProfiling, captureTypeProfile} from '../src/profile-schema-usage';
 
-suite('track-type-dependency-test', () => {
+suite('profile-schema-usage-test', () => {
   setup(() => {
-    resetTracker();
+    resetProfiler();
   });
 
   test('it reports the types used in a query', () => {
-    startTracking();
+    startProfiling();
 
     // eslint-disable-next-line no-new
     new Query(typeBundle, (root) => {
@@ -41,8 +41,8 @@ suite('track-type-dependency-test', () => {
     ]);
   });
 
-  test('it pauses tracking when `pauseTracking` is called', () => {
-    startTracking();
+  test('it pauses tracking when `pauseProfiling` is called', () => {
+    startProfiling();
 
     // eslint-disable-next-line no-new
     new Query(typeBundle, (root) => {
@@ -51,7 +51,7 @@ suite('track-type-dependency-test', () => {
       });
     });
 
-    pauseTracking();
+    pauseProfiling();
 
     // eslint-disable-next-line no-new
     new Query(typeBundle, (root) => {
@@ -66,7 +66,7 @@ suite('track-type-dependency-test', () => {
       });
     });
 
-    startTracking();
+    startProfiling();
 
     // eslint-disable-next-line no-new
     new Query(typeBundle, (root) => {
@@ -84,8 +84,8 @@ suite('track-type-dependency-test', () => {
     ]);
   });
 
-  test('it clears the tracked types when `resetTracker` is called', () => {
-    startTracking();
+  test('it clears the tracked types when `resetProfiler` is called', () => {
+    startProfiling();
 
     // eslint-disable-next-line no-new
     new Query(typeBundle, (root) => {
@@ -94,15 +94,15 @@ suite('track-type-dependency-test', () => {
       });
     });
 
-    resetTracker();
+    resetProfiler();
 
     assert.deepEqual(captureTypeProfile(), []);
   });
 
   test('it stops tracking when `resetTypes` is called (returning the tracker to it\'s initial state.', () => {
-    startTracking();
+    startProfiling();
 
-    resetTracker();
+    resetProfiler();
 
     // eslint-disable-next-line no-new
     new Query(typeBundle, (root) => {


### PR DESCRIPTION
Previously, field tracking only captured types and their fields. This normalizes the underlying profile to capture types (scalars too), and add fields to them when necessary. One weird thing is that the output of a profile with scalars is that those scalars will be represented as empty arrays. So empty arrays implicitly indicate that a thing is a scalar, but that really doesn't matter for the sake of profiling.