### PR TITLE
set GraphModel properties to be enumerable

### DIFF
--- a/src/graph-model.js
+++ b/src/graph-model.js
@@ -19,12 +19,14 @@ export default class GraphModel {
 
       if (attrs[key] === null) {
         descriptor = {
+          enumerable: true,
           get() {
             return null;
           }
         };
       } else {
         descriptor = {
+          enumerable: true,
           get() {
             return this.attrs[key].valueOf();
           }

--- a/src/graph-model.js
+++ b/src/graph-model.js
@@ -34,5 +34,6 @@ export default class GraphModel {
       }
       Object.defineProperty(this, key, descriptor);
     });
+    Object.defineProperty(this, 'attrs', { enumerable: false });
   }
 }

--- a/src/graph-model.js
+++ b/src/graph-model.js
@@ -10,7 +10,7 @@ export default class GraphModel {
    * @param {Object} attrs Attributes on the GraphModel.
    */
   constructor(attrs) {
-    this.attrs = attrs;
+    Object.defineProperty(this, 'attrs', {value: attrs, enumerable: false});
 
     Object.keys(this.attrs).filter((key) => {
       return !(key in this);
@@ -34,6 +34,5 @@ export default class GraphModel {
       }
       Object.defineProperty(this, key, descriptor);
     });
-    Object.defineProperty(this, 'attrs', { enumerable: false });
   }
 }

--- a/test/graph-model-test.js
+++ b/test/graph-model-test.js
@@ -27,7 +27,7 @@ suite('graph-model-test', () => {
 
     const model = new GraphModel(attrs);
 
-    assert.deepEqual(Object.keys(model), ['attrs', 'beans', 'beanType']);
+    assert.deepEqual(Object.keys(model), ['beans', 'beanType']);
   });
 
   test('it creates read-only proxies', () => {

--- a/test/graph-model-test.js
+++ b/test/graph-model-test.js
@@ -9,14 +9,12 @@ suite('graph-model-test', () => {
   };
 
   test('it stores passed attrs under attrs', () => {
-
     const model = new GraphModel(attrs);
 
     assert.deepEqual(model.attrs, attrs);
   });
 
   test('it creates top level proxies for all keys', () => {
-
     const model = new GraphModel(attrs);
 
     assert.equal(model.beans, attrs.beans);
@@ -24,14 +22,12 @@ suite('graph-model-test', () => {
   });
 
   test('it creates an object with enumerable keys', () => {
-
     const model = new GraphModel(attrs);
 
     assert.deepEqual(Object.keys(model), ['beans', 'beanType']);
   });
 
   test('it creates read-only proxies', () => {
-
     const model = new GraphModel(attrs);
 
     assert.throws(() => {
@@ -40,7 +36,6 @@ suite('graph-model-test', () => {
   });
 
   test('it doesn\'t overwrite existing keys', () => {
-
     class ModelWithBusinessLogic extends GraphModel {
       get beans() {
         return 'so-many';

--- a/test/graph-model-test.js
+++ b/test/graph-model-test.js
@@ -23,6 +23,13 @@ suite('graph-model-test', () => {
     assert.equal(model.beanType, attrs.beanType);
   });
 
+  test('it creates an object with enumerable keys', () => {
+
+    const model = new GraphModel(attrs);
+
+    assert.deepEqual(Object.keys(model), ['attrs', 'beans', 'beanType']);
+  });
+
   test('it creates read-only proxies', () => {
 
     const model = new GraphModel(attrs);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3063,14 +3063,14 @@ jsbn@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.0.tgz#650987da0dd74f4ebf5a11377a2aa2d273e97dfd"
 
-jsdoc-export-default-interop@^0.3.1:
+jsdoc-export-default-interop@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/jsdoc-export-default-interop/-/jsdoc-export-default-interop-0.3.1.tgz#462fa9f9b4a2ab06a0f4d0624143d02e5ba2d05f"
   dependencies:
     in-publish "^2.0.0"
     lodash "^4.0.1"
 
-jsdoc@^3.4.3:
+jsdoc@3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-3.4.3.tgz#e5740d6145c681f6679e6c17783a88dbdd97ccd3"
   dependencies:


### PR DESCRIPTION
this fixes the ability to use stuff like `Object.assign({}, graph-model-object)` properly, as Object.assign only works on properties which are enumerable. They are not set as enumerable by default when using `Object.defineProperty`.