### PR TITLE
fix jsnext default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Feature light client library for fetching resources via GraphQL",
   "main": "index.js",
   "module": "index.es.js",
+  "jsnext:main": "index.es.js",
   "license": "MIT",
   "author": "Shopify Inc.",
   "dependencies": {},


### PR DESCRIPTION
removal of `jsnext:main` entry point in release v0.5.0 was causing issues in `js-buy-sdk`.

ran into the issue here: https://github.com/Shopify/js-buy-sdk/pull/381