### PR TITLE
Persist vars on `Client#fetchNextPage` requests

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -109,14 +109,14 @@ export default class Client {
    * Sends a GraphQL operation (query or mutation) or a document.
    *
    * @example
-   * client.send(query, [{id: '12345'}]).then((result) => {
+   * client.send(query, {id: '12345'}).then((result) => {
    *   // Do something with the returned result
    *   console.log(result);
    * });
    *
    * @param {(Query|Mutation|Document|Function)} request The operation or document to send. If represented
    * as a function, it must return `Query`, `Mutation`, or `Document` and recieve the client as the only param.
-   * @param {Object[]} [variableValues] The values for variables in the operation or document.
+   * @param {Object} [variableValues] The values for variables in the operation or document.
    * @param {Object} [otherProperties] Other properties to send with the query. For example, a custom operation name.
    * @return {Promise.<Object>} A promise resolving to an object containing the response data.
    */

--- a/src/client.js
+++ b/src/client.js
@@ -160,7 +160,10 @@ export default class Client {
 
     return this.fetcher(graphQLParams).then((response) => {
       if (response.data) {
-        response.model = decode(operation, response.data, {classRegistry: this.classRegistry});
+        response.model = decode(operation, response.data, {
+          classRegistry: this.classRegistry,
+          variableValues
+        });
       }
 
       return response;
@@ -191,8 +194,13 @@ export default class Client {
     }
 
     const [query, path] = node.nextPageQueryAndPath();
+    let variableValues;
 
-    return this.send(query, options).then((response) => {
+    if (variableValues || options) {
+      variableValues = Object.assign({}, node.variableValues, options);
+    }
+
+    return this.send(query, variableValues).then((response) => {
       response.model = path.reduce((object, key) => {
         return object[key];
       }, response.model);

--- a/src/decode.js
+++ b/src/decode.js
@@ -127,11 +127,11 @@ function recordTypeInformation(context, value) {
   return value;
 }
 
-function defaultTransformers({classRegistry = new ClassRegistry()}) {
+function defaultTransformers({classRegistry = new ClassRegistry(), variableValues}) {
   return [
     transformScalars,
     generateRefetchQueries,
-    transformConnections,
+    transformConnections(variableValues),
     recordTypeInformation,
     transformPojosToClassesWithRegistry(classRegistry)
   ];

--- a/src/transform-connection.js
+++ b/src/transform-connection.js
@@ -118,20 +118,23 @@ function hasPreviousPage(connection, edge) {
   return connection.pageInfo.hasPreviousPage;
 }
 
-export default function transformConnections(context, value) {
-  if (isConnection(context)) {
-    if (!(value.pageInfo && value.pageInfo.hasOwnProperty('hasNextPage') && value.pageInfo.hasOwnProperty('hasPreviousPage'))) {
-      throw new Error('Connections must include the selections "pageInfo { hasNextPage, hasPreviousPage }".');
-    }
+export default function transformConnections(variableValues) {
+  return function(context, value) {
+    if (isConnection(context)) {
+      if (!(value.pageInfo && value.pageInfo.hasOwnProperty('hasNextPage') && value.pageInfo.hasOwnProperty('hasPreviousPage'))) {
+        throw new Error('Connections must include the selections "pageInfo { hasNextPage, hasPreviousPage }".');
+      }
 
-    return value.edges.map((edge) => {
-      return Object.assign(edge.node, {
-        nextPageQueryAndPath: nextPageQueryAndPath(context, edge.cursor),
-        hasNextPage: hasNextPage(value, edge),
-        hasPreviousPage: hasPreviousPage(value, edge)
+      return value.edges.map((edge) => {
+        return Object.assign(edge.node, {
+          nextPageQueryAndPath: nextPageQueryAndPath(context, edge.cursor),
+          hasNextPage: hasNextPage(value, edge),
+          hasPreviousPage: hasPreviousPage(value, edge),
+          variableValues
+        });
       });
-    });
-  } else {
-    return value;
-  }
+    } else {
+      return value;
+    }
+  };
 }

--- a/src/transform-connection.js
+++ b/src/transform-connection.js
@@ -1,6 +1,6 @@
 import Query from './query';
 import isNodeContext from './is-node-context';
-import variable from './variable';
+import variable, {VariableDefinition} from './variable';
 import Scalar from './scalar';
 
 function isConnection(context) {
@@ -69,9 +69,15 @@ function nextPageQueryAndPath(context, cursor) {
       const nodeType = nearestNodeContext.selection.selectionSet.typeSchema;
       const nodeId = nearestNodeContext.responseData.id;
       const contextChain = contextsFromNearestNode(context);
-      const first = contextChain[contextChain.length - 1].selection.args.first;
+      const lastInChain = contextChain[contextChain.length - 1];
+      const first = lastInChain.selection.args.first;
+      const variableDefinitions = Object.keys(lastInChain.selection.args).filter((key) => {
+        return VariableDefinition.prototype.isPrototypeOf(lastInChain.selection.args[key]);
+      }).map((key) => {
+        return lastInChain.selection.args[key];
+      });
 
-      const query = new Query(context.selection.selectionSet.typeBundle, [variable('first', 'Int', first)], (root) => {
+      const query = new Query(context.selection.selectionSet.typeBundle, variableDefinitions.concat(variable('first', 'Int', first)), (root) => {
         path.push('node');
         root.add('node', {args: {id: nodeId}}, (node) => {
           node.addInlineFragmentOn(nodeType.name, (fragment) => {


### PR DESCRIPTION
If the original request that included a connection type included vars, include those variable definitions and values in subsequent requests, optionally allowing the requester to overwrite them.

Prior to this change, a query may have had vars in field arguments that would not be defined on the root query, and their values would be lost after the first request. This change fixes that behaviour