### PR TITLE
Fix variables on generated pagination queries

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -196,7 +196,7 @@ export default class Client {
     const [query, path] = node.nextPageQueryAndPath();
     let variableValues;
 
-    if (variableValues || options) {
+    if (node.variableValues || options) {
       variableValues = Object.assign({}, node.variableValues, options);
     }
 

--- a/src/selection-set.js
+++ b/src/selection-set.js
@@ -123,6 +123,11 @@ export class FragmentSpread extends Spread {
   toString() {
     return `...${this.name}`;
   }
+
+  toDefinition() {
+    // eslint-disable-next-line no-use-before-define
+    return new FragmentDefinition(this.name, this.selectionSet.typeSchema.name, this.selectionSet);
+  }
 }
 
 export class FragmentDefinition {

--- a/test/client-fetch-next-page-test.js
+++ b/test/client-fetch-next-page-test.js
@@ -174,4 +174,26 @@ suite('client-fetch-next-page-test', () => {
       assert.equal(fetcherGraphQLParams.variables.sort, 'ID');
     });
   });
+
+  test('it fetches the next page with persistent variable values when no values are specified', () => {
+    const fetcher = mockFetcherMultiple();
+    const mockClient = new Client(typeBundle, {fetcher});
+    const sortVar = mockClient.variable('sort', 'ProductSortKeys');
+    const queryWithAdditionalVars = new Query(typeBundle, [sortVar], (root) => {
+      root.add('shop', (shop) => {
+        shop.addConnection('collections', {args: {first: 1}}, (collection) => {
+          collection.addConnection('products', {args: {first: 1, sortKey: sortVar}}, (product) => {
+            product.add('handle');
+          });
+        });
+      });
+    });
+
+    const decodedWithAdditionalVars = decode(queryWithAdditionalVars, pageOneData, {variableValues: {sort: 'ID'}});
+
+    return mockClient.fetchNextPage(decodedWithAdditionalVars.shop.collections[0].products).then(() => {
+      assert.equal(fetcherGraphQLParams.query, decodedWithAdditionalVars.shop.collections[0].products[0].nextPageQueryAndPath()[0].toString());
+      assert.equal(fetcherGraphQLParams.variables.sort, 'ID');
+    });
+  });
 });

--- a/test/named-fragment-test.js
+++ b/test/named-fragment-test.js
@@ -33,6 +33,12 @@ suite('named-fragment-test', () => {
     assert.deepEqual(definition.spread.toString(), '...sickFragment');
   });
 
+  test('it can generate a definition from a spread', () => {
+    const definition = new FragmentDefinition('sickFragment', typeName, selections);
+    const spread = definition.spread;
+
+    assert.equal(spread.toDefinition().toString(), definition.toString());
+  });
 
   test('it is deeply frozen after being built.', () => {
     const definition = new FragmentDefinition('sickFragment', typeName, selections);


### PR DESCRIPTION
On the first pass of this, a couple cases were missed. Primarily, working off of nearest node instead of the root.

The second thing was that we weren't including fragment definitions for any of the fragments that were used in the generated query, since we worked on a query alone, and not a document. This PR adds in definitions for fragments that exist in any of the selection sets