### PR TITLE
Fix an issue where the path to the paginated set was mutating per-call

### DIFF
--- a/src/transform-connection.js
+++ b/src/transform-connection.js
@@ -101,10 +101,10 @@ function collectFragments(selections) {
 
 function nextPageQueryAndPath(context, cursor) {
   const nearestNodeContext = nearestNode(context);
-  const path = [];
 
   if (nearestNodeContext) {
     return function() {
+      const path = [];
       const nodeType = nearestNodeContext.selection.selectionSet.typeSchema;
       const nodeId = nearestNodeContext.responseData.id;
       const contextChain = contextsFromNearestNode(context);
@@ -127,6 +127,7 @@ function nextPageQueryAndPath(context, cursor) {
     };
   } else {
     return function() {
+      const path = [];
       const contextChain = contextsFromRoot(context);
       const [document, variableDefinitions] = initializeDocumentAndVars(context, contextChain);
 

--- a/test/decode-next-page-query-test.js
+++ b/test/decode-next-page-query-test.js
@@ -109,6 +109,14 @@ suite('decode-next-page-query-test', () => {
     assert.deepEqual(path, ['shop', 'collections']);
   });
 
+  test('Arrays of Nodes can generate a query to fetch the next page', () => {
+    const [_, pathFirstCall] = decoded.shop.collections[0].nextPageQueryAndPath();
+    const [__, pathSecondCall] = decoded.shop.collections[0].nextPageQueryAndPath();
+
+    assert.deepEqual(pathFirstCall, ['shop', 'collections']);
+    assert.deepEqual(pathFirstCall, pathSecondCall);
+  });
+
   test('Arrays of Nodes nested under a truncated query to fetch their next page', () => {
     const [nextPageQuery, path] = decoded.shop.products[0].variants[0].nextPageQueryAndPath();
 


### PR DESCRIPTION
The test in the diff illustrates the outcome we want. What we were getting was a path like `['shop', 'collections']`, and then on a second call `['shop', 'collections', 'shop', 'collections']`, which was caused by hoisting the `path` var into a shared context.