### PR TITLE
Added ability to provide custom headers on a request by request basis

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -118,9 +118,10 @@ export default class Client {
    * as a function, it must return `Query`, `Mutation`, or `Document` and recieve the client as the only param.
    * @param {Object} [variableValues] The values for variables in the operation or document.
    * @param {Object} [otherProperties] Other properties to send with the query. For example, a custom operation name.
+   * @param {Object} [headers] Aditional headers to be applied on a request by request basis.
    * @return {Promise.<Object>} A promise resolving to an object containing the response data.
    */
-  send(request, variableValues = null, otherProperties = null) {
+  send(request, variableValues = null, otherProperties = null, headers = null) {
     let operationOrDocument;
 
     if (Function.prototype.isPrototypeOf(request)) {
@@ -158,7 +159,7 @@ export default class Client {
       }
     }
 
-    return this.fetcher(graphQLParams).then((response) => {
+    return this.fetcher(graphQLParams, headers).then((response) => {
       if (response.data) {
         response.model = decode(operation, response.data, {
           classRegistry: this.classRegistry,

--- a/src/client.js
+++ b/src/client.js
@@ -118,7 +118,7 @@ export default class Client {
    * as a function, it must return `Query`, `Mutation`, or `Document` and recieve the client as the only param.
    * @param {Object} [variableValues] The values for variables in the operation or document.
    * @param {Object} [otherProperties] Other properties to send with the query. For example, a custom operation name.
-   * @param {Object} [headers] Aditional headers to be applied on a request by request basis.
+   * @param {Object} [headers] Additional headers to be applied on a request by request basis.
    * @return {Promise.<Object>} A promise resolving to an object containing the response data.
    */
   send(request, variableValues = null, otherProperties = null, headers = null) {

--- a/src/http-fetcher.js
+++ b/src/http-fetcher.js
@@ -1,5 +1,5 @@
 export default function httpFetcher(url, options = {}) {
-  return function fetcher(graphQLParams) {
+  return function fetcher(graphQLParams, headers = null) {
     return fetch(url, {
       body: JSON.stringify(graphQLParams),
       method: 'POST',
@@ -8,7 +8,8 @@ export default function httpFetcher(url, options = {}) {
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json',
-        ...options.headers
+        ...options.headers,
+        ...headers
       }
     }).then((response) => response.json());
   };

--- a/src/http-fetcher.js
+++ b/src/http-fetcher.js
@@ -1,5 +1,5 @@
 export default function httpFetcher(url, options = {}) {
-  return function fetcher(graphQLParams, headers = null) {
+  return function fetcher(graphQLParams, headers) {
     return fetch(url, {
       body: JSON.stringify(graphQLParams),
       method: 'POST',

--- a/test/http-fetcher-test.js
+++ b/test/http-fetcher-test.js
@@ -80,10 +80,8 @@ suite('http-fetcher-test', () => {
       query: '{ shop { name } }',
       variables: {}
     };
-
     const customHeaders = {'X-API-KEY': '12345'};
     const fetcher = httpFetcher('https://graphql.example.com', {headers: customHeaders});
-
     const requestTimeHeaders = {Authorization: 'abcde'};
 
     return fetcher(request, requestTimeHeaders).then(() => {

--- a/test/http-fetcher-test.js
+++ b/test/http-fetcher-test.js
@@ -75,7 +75,7 @@ suite('http-fetcher-test', () => {
     });
   });
 
-  test('it should allow setting custom headers as request time', () => {
+  test('it should allow setting custom headers at request time', () => {
     const request = {
       query: '{ shop { name } }',
       variables: {}
@@ -84,16 +84,16 @@ suite('http-fetcher-test', () => {
     const customHeaders = {'X-API-KEY': '12345'};
     const fetcher = httpFetcher('https://graphql.example.com', {headers: customHeaders});
 
-    const customHeadersRequestTime = {Authorization: 'abcde'};
+    const requestTimeHeaders = {Authorization: 'abcde'};
 
-    return fetcher(request, customHeadersRequestTime).then(() => {
+    return fetcher(request, requestTimeHeaders).then(() => {
       const [_url, {headers}] = fetchMock.lastCall();
 
       assert.deepEqual(headers, {
         'Content-Type': 'application/json',
         Accept: 'application/json',
         ...customHeaders,
-        ...customHeadersRequestTime
+        ...requestTimeHeaders
       });
     });
   });

--- a/test/http-fetcher-test.js
+++ b/test/http-fetcher-test.js
@@ -74,4 +74,27 @@ suite('http-fetcher-test', () => {
       });
     });
   });
+
+  test('it should allow setting custom headers as request time', () => {
+    const request = {
+      query: '{ shop { name } }',
+      variables: {}
+    };
+
+    const customHeaders = {'X-API-KEY': '12345'};
+    const fetcher = httpFetcher('https://graphql.example.com', {headers: customHeaders});
+
+    const customHeadersRequestTime = {Authorization: 'abcde'};
+
+    return fetcher(request, customHeadersRequestTime).then(() => {
+      const [_url, {headers}] = fetchMock.lastCall();
+
+      assert.deepEqual(headers, {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        ...customHeaders,
+        ...customHeadersRequestTime
+      });
+    });
+  });
 });


### PR DESCRIPTION
I would like to continue to use this client as it's integration with Rollup via "rollup-plugin-graphql-js-client-compiler" is an awesome dev experience.

The one thing missing that I've ran across so far is the ability to specify headers outside of the Client constructor.

I've updated the codebase to add in the ability to provide a 4th argument to Client.send that get's passed along to the httpFetcher "instance".