### PR TITLE
Updated interface support

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -25,6 +25,22 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "discountApplication",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "DiscountApplication",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -452,6 +468,241 @@
           ],
           "inputFields": null,
           "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "DiscountApplicationTargetSelection",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "ALL",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENTITLED",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "EXPLICIT",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "DiscountApplicationTargetType",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "LINE_ITEM",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SHIPPING_LINE",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DiscountCodeApplication",
+          "description": null,
+          "fields": [
+            {
+              "name": "code",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "targetSelection",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DiscountApplicationTargetSelection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "targetType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DiscountApplicationTargetType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "DiscountApplication",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "DiscountApplication",
+          "fields": [
+            {
+              "name": "targetSelection",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DiscountApplicationTargetSelection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "targetType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DiscountApplicationTargetType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "DiscountCodeApplication",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "ManualDiscountApplication",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ManualDiscountApplication",
+          "description": null,
+          "fields": [
+            {
+              "name": "targetSelection",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DiscountApplicationTargetSelection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "targetType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DiscountApplicationTargetType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "DiscountApplication",
+              "ofType": null
+            }
+          ],
           "enumValues": null,
           "possibleTypes": null
         },

--- a/src/decode.js
+++ b/src/decode.js
@@ -116,11 +116,13 @@ function transformScalars(context, value) {
 }
 
 function recordTypeInformation(context, value) {
+  const {typeBundle, typeSchema} = context.selection.selectionSet;
+
   if (isValue(value)) {
     if (value.__typename) {
-      value.type = schemaForType(context.selection.selectionSet.typeBundle, value.__typename);
+      value.type = schemaForType(typeBundle, value.__typename, typeSchema);
     } else {
-      value.type = context.selection.selectionSet.typeSchema;
+      value.type = typeSchema;
     }
   }
 

--- a/src/schema-for-type.js
+++ b/src/schema-for-type.js
@@ -1,10 +1,11 @@
-export default function schemaForType(typeBundle, typeName) {
+export default function schemaForType(typeBundle, typeName, typeSchema = null) {
   const type = typeBundle.types[typeName];
 
   if (type) {
     return type;
+  } else if (typeSchema && typeSchema.kind === 'INTERFACE') {
+    return typeSchema;
   }
 
   throw new Error(`No type of ${typeName} found in schema`);
 }
-

--- a/test/decode-unknown-type-test.js
+++ b/test/decode-unknown-type-test.js
@@ -1,0 +1,63 @@
+import assert from 'assert';
+import decode from '../src/decode';
+import Query from '../src/query';
+import typeBundle from '../fixtures/types'; // eslint-disable-line import/no-unresolved
+
+const checkoutQuery = new Query(typeBundle, (root) => {
+  root.add('node', {args: {id: 'gid://shopify/Checkout/1'}}, (node) => {
+    node.addInlineFragmentOn('Checkout', (checkout) => {
+      checkout.add('discountApplication', (discount) => {
+        discount.add('targetSelection');
+        discount.add('targetType');
+        discount.addInlineFragmentOn('DiscountCodeApplication', (application) => {
+          application.add('code');
+        });
+      });
+    });
+  });
+});
+
+suite('decode-unknown-type-test', () => {
+  test('it decodes an interface into a type', () => {
+    const data = {
+      node: {
+        __typename: 'Checkout',
+        discountApplication: {
+          __typename: 'DiscountCodeApplication',
+          targetSelection: 'ALL',
+          targetType: 'SHIPPING_LINE',
+          code: 'SHIPPINGFREE'
+        }
+      }
+    };
+
+    const decoded = decode(checkoutQuery, data);
+
+    assert.ok(decoded);
+    assert.equal(decoded.node.discountApplication.type.name, 'DiscountCodeApplication');
+    assert.equal(decoded.node.discountApplication.targetSelection, data.node.discountApplication.targetSelection);
+    assert.equal(decoded.node.discountApplication.targetType, data.node.discountApplication.targetType);
+    assert.equal(decoded.node.discountApplication.code, data.node.discountApplication.code);
+  });
+
+  test('it decodes an unknown interface into a base type', () => {
+    const data = {
+      node: {
+        __typename: 'Checkout',
+        discountApplication: {
+          __typename: 'AutomaticDiscountApplication',
+          targetSelection: 'ALL',
+          targetType: 'SHIPPING_LINE'
+        }
+      }
+    };
+
+    const decoded = decode(checkoutQuery, data);
+
+    assert.ok(decoded);
+    assert.equal(decoded.node.discountApplication.type.name, 'DiscountApplication');
+    assert.equal(decoded.node.discountApplication.targetSelection, data.node.discountApplication.targetSelection);
+    assert.equal(decoded.node.discountApplication.targetType, data.node.discountApplication.targetType);
+    assert.equal(decoded.node.discountApplication.code, null);
+  });
+});

--- a/test/schema-type-test.js
+++ b/test/schema-type-test.js
@@ -1,27 +1,34 @@
 import assert from 'assert';
-import typeBundle from '../fixtures/custom-type-bundle';
+import customTypeBundle from '../fixtures/custom-type-bundle';
 import schemaForType from '../src/schema-for-type';
 import Query from '../src/query';
 import Mutation from '../src/mutation';
+import typeBundle from '../fixtures/types'; // eslint-disable-line import/no-unresolved
 
 suite('schema-type-test', () => {
   test('queries use the query type from the schema', () => {
     let rootType = null;
-    const query = new Query(typeBundle, (root) => {
+    const query = new Query(customTypeBundle, (root) => {
       rootType = root.typeSchema;
     });
 
-    assert.deepEqual(schemaForType(typeBundle, 'CustomQueryRoot'), rootType);
-    assert.deepEqual(schemaForType(typeBundle, 'CustomQueryRoot'), query.typeSchema);
+    assert.deepEqual(schemaForType(customTypeBundle, 'CustomQueryRoot'), rootType);
+    assert.deepEqual(schemaForType(customTypeBundle, 'CustomQueryRoot'), query.typeSchema);
   });
 
   test('mutations use the mutation type from the schema', () => {
     let rootType = null;
-    const mutation = new Mutation(typeBundle, (root) => {
+    const mutation = new Mutation(customTypeBundle, (root) => {
       rootType = root.typeSchema;
     });
 
-    assert.deepEqual(schemaForType(typeBundle, 'CustomMutation'), rootType);
-    assert.deepEqual(schemaForType(typeBundle, 'CustomMutation'), mutation.typeSchema);
+    assert.deepEqual(schemaForType(customTypeBundle, 'CustomMutation'), rootType);
+    assert.deepEqual(schemaForType(customTypeBundle, 'CustomMutation'), mutation.typeSchema);
+  });
+
+  test('returns the correct type for an enum', () => {
+    const currencyCodeType = typeBundle.types.CurrencyCode;
+
+    assert.deepEqual(schemaForType(typeBundle, 'CurrencyCode'), currencyCodeType);
   });
 });


### PR DESCRIPTION
Adds support for falling back when interface objects can't be translated.
Relates to https://github.com/Shopify/js-buy-sdk/issues/614

I'm trying to fix the situation in the linked issue, which is outlined below:
- The GraphQL schema has an interface type (`DiscountApplication`)
- There is a new implementation type on the server (`AutomaticDiscountApplication`)
- The schema is updated in a new client version.
- The server starts returning `AutomaticDiscountApplication` objects to an old version of the client, which does not have a definition for it in the schema. Instead of failing silently / falling back, the query 
returns an error.
