### PR TITLE
Fallback to text in catch block

### DIFF
--- a/src/http-fetcher.js
+++ b/src/http-fetcher.js
@@ -12,13 +12,11 @@ export default function httpFetcher(url, options = {}) {
         ...headers
       }
     }).then((response) => {
-      const contentType = response.headers.get('content-type');
+      const responseCopy = response.clone();
 
-      if (contentType.includes('application/json')) {
-        return response.json();
-      }
-
-      return response.text().then((text) => ({text}));
+      return response.json().catch(() => {
+        return responseCopy.text().then((text) => ({text}));
+      });
     });
   };
 }

--- a/test/http-fetcher-test.js
+++ b/test/http-fetcher-test.js
@@ -4,12 +4,7 @@ import httpFetcher from '../src/http-fetcher';
 
 suite('http-fetcher-test', () => {
   setup(() => {
-    fetchMock.mock('https://graphql.example.com', {
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: {data: {}}
-    });
+    fetchMock.mock('https://graphql.example.com', {data: {}});
   });
 
   teardown(() => {
@@ -44,17 +39,12 @@ suite('http-fetcher-test', () => {
     });
   });
 
-  test('it should handle non-json repsonses', () => {
+  test('it should handle non-json responses', () => {
     fetchMock.restore();
 
     const responseBody = 'Text Response';
 
-    fetchMock.mock('https://graphql.example.com', {
-      headers: {
-        'Content-Type': 'text/html'
-      },
-      body: responseBody
-    });
+    fetchMock.mock('https://graphql.example.com', responseBody);
 
     const request = {
       query: '{ shop { name } }',


### PR DESCRIPTION
Let's fallback to `response.text()` only when `response.json()` fails. I think this is acceptable since the general use case is `application/json` - and the `text/html` case is rare.