### PR TITLE
Replace includes with indexOf for IE

### DIFF
--- a/src/http-fetcher.js
+++ b/src/http-fetcher.js
@@ -14,7 +14,7 @@ export default function httpFetcher(url, options = {}) {
     }).then((response) => {
       const contentType = response.headers.get('content-type');
 
-      if (contentType.includes('application/json')) {
+      if (contentType.indexOf('application/json') > -1) {
         return response.json();
       }
 


### PR DESCRIPTION
To allow consuming libraries to [support IE](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#Browser_compatibility), `indexOf` should be used in favor of `includes`