### PR TITLE
Add support for directives on fields

### DIFF
--- a/src/format-directives.js
+++ b/src/format-directives.js
@@ -1,0 +1,16 @@
+import formatObject from './format-object';
+import join from './join';
+
+export default function formatDirectives(directives) {
+  if (!Object.keys(directives).length) {
+    return '';
+  }
+
+  const directiveStrings = Object.keys(directives).map((key) => {
+    const arg = directives[key] ? `(${formatObject(directives[key])})` : '';
+
+    return `@${key}${arg}`;
+  });
+
+  return ` ${join(...directiveStrings)}`;
+}

--- a/src/format-directives.js
+++ b/src/format-directives.js
@@ -7,7 +7,8 @@ export default function formatDirectives(directives) {
   }
 
   const directiveStrings = Object.keys(directives).map((key) => {
-    const arg = directives[key] ? `(${formatObject(directives[key])})` : '';
+    const directiveArgs = directives[key];
+    const arg = (directiveArgs && Object.keys(directiveArgs).length) ? `(${formatObject(directiveArgs)})` : '';
 
     return `@${key}${arg}`;
   });

--- a/src/selection-set.js
+++ b/src/selection-set.js
@@ -2,6 +2,7 @@ import deepFreezeCopyExcept from './deep-freeze-copy-except';
 import join from './join';
 import schemaForType from './schema-for-type';
 import formatArgs from './format-args';
+import formatDirectives from './format-directives';
 import noop from './noop';
 import {isVariable} from './variable';
 import Profiler from './profile-schema-usage';
@@ -36,6 +37,7 @@ function parseFieldCreationArgs(creationArgs) {
 }
 
 const emptyArgs = Object.freeze({});
+const emptyDirectives = Object.freeze({});
 
 export class Field {
 
@@ -48,6 +50,7 @@ export class Field {
    * @param {Object} [options] An options object containing:
    *   @param {Object} [options.args] Arguments for the field.
    *   @param {String} [options.alias] An alias for the field.
+   *   @param {Object} [options.directives] Directives for the field.
    * @param {SelectionSet} selectionSet The selection set on the field.
    */
   constructor(name, options, selectionSet) {
@@ -55,6 +58,7 @@ export class Field {
     this.alias = options.alias || null;
     this.responseKey = this.alias || this.name;
     this.args = (options.args ? deepFreezeCopyExcept(isVariable, options.args) : emptyArgs);
+    this.directives = (options.directives ? deepFreezeCopyExcept(isVariable, options.directives) : emptyDirectives);
     this.selectionSet = selectionSet;
     Object.freeze(this);
   }
@@ -67,7 +71,7 @@ export class Field {
   toString() {
     const aliasPrefix = this.alias ? `${this.alias}: ` : '';
 
-    return `${aliasPrefix}${this.name}${formatArgs(this.args)}${this.selectionSet}`;
+    return `${aliasPrefix}${this.name}${formatArgs(this.args)}${formatDirectives(this.directives)}${this.selectionSet}`;
   }
 }
 

--- a/test/format-directives-test.js
+++ b/test/format-directives-test.js
@@ -1,0 +1,61 @@
+import assert from 'assert';
+import formatDirectives from '../src/format-directives';
+import variable from '../src/variable';
+import _enum from '../src/enum';
+import Scalar from '../src/scalar';
+
+suite('format-directives-test', () => {
+  test('it formats directives with scalars', () => {
+    const result = formatDirectives({include: {int: 1, float: 0.1, string: 'two', boolean: true}});
+
+    assert.equal(result, ' @include(int: 1 float: 0.1 string: "two" boolean: true)');
+  });
+
+  test('it formats directives with input objects', () => {
+    const result = formatDirectives({skip: {object: {int: 1, float: 0.1, string: 'two', boolean: true}, secondInt: 1}});
+
+    assert.equal(result, ' @skip(object: {int: 1 float: 0.1 string: "two" boolean: true} secondInt: 1)');
+  });
+
+  test('it formats directives with lists', () => {
+    const result = formatDirectives({directive: {list: ['item1', 'item2']}});
+
+    assert.equal(result, ' @directive(list: ["item1" "item2"])');
+  });
+
+  test('it formats directives with enums', () => {
+    const result = formatDirectives({directive: {enumOne: _enum('ONE'), enumTwo: _enum('TWO')}});
+
+    assert.equal(result, ' @directive(enumOne: ONE enumTwo: TWO)');
+  });
+
+  test('it formats directives with lists of enums', () => {
+    const result = formatDirectives({directive: {list: [_enum('ONE'), _enum('TWO')]}});
+
+    assert.equal(result, ' @directive(list: [ONE TWO])');
+  });
+
+  test('it formats directives with wrapped scalars', () => {
+    const result = formatDirectives({include: {int: new Scalar(1), float: new Scalar(0.1), string: new Scalar('two'), boolean: new Scalar(true)}});
+
+    assert.equal(result, ' @include(int: 1 float: 0.1 string: "two" boolean: true)');
+  });
+
+  test('it formats directives with variables', () => {
+    const result = formatDirectives({include: {if: variable('includeBool', 'Boolean')}});
+
+    assert.equal(result, ' @include(if: $includeBool)');
+  });
+
+  test('it formats directives with null values', () => {
+    const result = formatDirectives({upper: null});
+
+    assert.equal(result, ' @upper');
+  });
+
+  test('it formats multiple directives', () => {
+    const result = formatDirectives({include: {if: variable('includeBool', 'Boolean')}, upper: null, format: {as: 'YYYY'}});
+
+    assert.equal(result, ' @include(if: $includeBool) @upper @format(as: "YYYY")');
+  });
+});

--- a/test/format-directives-test.js
+++ b/test/format-directives-test.js
@@ -53,6 +53,12 @@ suite('format-directives-test', () => {
     assert.equal(result, ' @upper');
   });
 
+  test('it formats directives with empty objects', () => {
+    const result = formatDirectives({upper: {}});
+
+    assert.equal(result, ' @upper');
+  });
+
   test('it formats multiple directives', () => {
     const result = formatDirectives({include: {if: variable('includeBool', 'Boolean')}, upper: null, format: {as: 'YYYY'}});
 


### PR DESCRIPTION
* Add support for directives by adding an additional `directives` option on fields
* The GraphQL spec currently only supports `include` and `skip` directives but I made the API more generalized to accommodate for any custom directives that consumers may have 

* Example adding a node with a directive
```
node.add('name', { 
    directives: {
      directiveOne: {
        argKey: 'argValue'
      },
      directiveTwo: null  // we could also change the directives API to expect an empty object instead
    },
  },
);
```
* Resulting in the following field in the query
`name @directiveOne(argKey: "argValue") @directiveTwo`