### PR TITLE
Fix issue when initializing first variables

### DIFF
--- a/src/transform-connection.js
+++ b/src/transform-connection.js
@@ -51,8 +51,12 @@ function initializeDocumentAndVars(currentContext, contextChain) {
   });
 
   if (!firstVar) {
-    firstVar = variable('first', 'Int', first);
-    variableDefinitions.push(firstVar);
+    if (isVariable(first)) {
+      firstVar = first;
+    } else {
+      firstVar = variable('first', 'Int', first);
+      variableDefinitions.push(firstVar);
+    }
   }
 
   const document = new Document(currentContext.selection.selectionSet.typeBundle);


### PR DESCRIPTION
If a variable named other than `first` is used for the first argument, the `nextPageQueryAndPath` query will be invalid, causing an error. 
For example, if there is a variable named `productsFirst` being used as the first argument on products, the resulting query to fetch the next page of products will be invalid GraphQL:
```
query($productsFirst:Int!, $first:Int = $productsFirst) {
  ...
  products(first: $productFirst) {...}
  ...
}
```
This [JS Buy SDK codepen](https://codepen.io/spencercanner/pen/XWWvjNw) logs an invalid `nextPageQueryAndPath` query, as well as the error which occurs when calling `fetchNextPage`, for a [collection with products query](https://github.com/Shopify/js-buy-sdk/blob/master/src/graphql/collectionNodeWithProductsQuery.graphql#L5).

This PR resolves the issue by adding a first variable only if there are no variables named `first` and the first argument is not a variable. 